### PR TITLE
fixing redisConfig parameter

### DIFF
--- a/src/app/lib/Queue.js
+++ b/src/app/lib/Queue.js
@@ -4,7 +4,7 @@ import redisConfig from '../../config/redis';
 import * as jobs from '../jobs';
 
 const queues = Object.values(jobs).map(job => ({
-  bull: new Queue(job.key, redisConfig),
+  bull: new Queue(job.key, `redis://${redisConfig.host}:${redisConfig.port}`),
   name: job.key,
   handle: job.handle,
   options: job.options,


### PR DESCRIPTION
O redisConfig não consegue entender o host e a porta configuradas, da forma que está passando no construtor. No seu código funcionou, pois o redis estava no docker e mapeou pro 127.0.0.1, e então, ele entendeu o host padrão. Peguei esse erro quando tentei fazer um container ler o redis de outro container, e neste caso, meu host do redis se chamava "redis". Pra arrumar, deve passar a url da conexão, dessa forma: 


de: 
const mailQueue = new Queue(RegistrationMail.key, redisConfig)


para: 
const mailQueue = new Queue(RegistrationMail.key, `redis://${redisConfig.host}:${redisConfig.port}`)
